### PR TITLE
Add email with coravel.mailer

### DIFF
--- a/Matcha.API/Helpers/Mailer.cs
+++ b/Matcha.API/Helpers/Mailer.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+using Matcha.API.Models;
+using CInterfaces = Coravel.Mailer.Mail.Interfaces;
+
+namespace Matcha.API.Helpers
+{
+    public interface IMailer
+    {
+        Task SendMail(Mailable mailable);
+    }
+
+    public class Mailer : IMailer
+    {
+        private CInterfaces.IMailer _mailer;
+
+        public Mailer(CInterfaces.IMailer mailer) => _mailer = mailer;
+
+        public Task SendMail(Mailable mailable) => _mailer.SendAsync(mailable);
+    }
+}

--- a/Matcha.API/Matcha.API.csproj
+++ b/Matcha.API/Matcha.API.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>b7d355c7-6699-4a3a-84c1-73666f147595</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Coravel.Mailer" Version="1.0.3" />
+    <PackageReference Include="Coravel.Mailer" Version="3.0.0-preview1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0"/>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.0.0"/>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.0.0"/>

--- a/Matcha.API/Matcha.API.csproj
+++ b/Matcha.API/Matcha.API.csproj
@@ -4,6 +4,7 @@
     <UserSecretsId>b7d355c7-6699-4a3a-84c1-73666f147595</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Coravel.Mailer" Version="1.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0"/>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.0.0"/>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.0.0"/>

--- a/Matcha.API/Models/Email.cs
+++ b/Matcha.API/Models/Email.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace Matcha.API.Models
+{
+    public class MailUser
+    {
+        public string Name;
+        public string Email;
+    }
+    public class Email
+    {
+        public List<MailUser> To;
+        public List<MailUser> Cc = new List<MailUser>();
+        public List<MailUser> Bcc = new List<MailUser>();
+        public MailUser ReplyTo;
+        public string HTML;
+        public string Subject;
+    }
+}

--- a/Matcha.API/Models/Mailable.cs
+++ b/Matcha.API/Models/Mailable.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using Coravel.Mailer.Mail;
+
+namespace Matcha.API.Models
+{
+    public class Mailable : Mailable<Mailable>
+    {
+        private Email _email;
+
+        public Mailable(Email email)
+        {
+            if (email.To == null || email.To.Count == 0)
+                throw new ArgumentNullException("email.To", "To List is empty");
+            if (string.IsNullOrEmpty(email.HTML))
+                throw new ArgumentNullException("email.HTML", "HTML is empty");
+            if (string.IsNullOrEmpty(email.Subject))
+                throw new ArgumentNullException("email.Subject", "Subject is empty");
+            _email = email;
+        }
+
+        public override void Build()
+        {
+            Html(_email.HTML);
+            Subject(_email.Subject);
+
+            var _toList = new List<MailRecipient>();
+            foreach (var mailUser in _email.To)
+            {
+                _toList.Add(new MailRecipient(
+                    mailUser.Email,
+                    mailUser.Name
+                ));
+            }
+            To(_toList);
+
+            var _ccList = new List<MailRecipient>();
+            foreach (var mailUser in _email.Cc)
+            {
+                _ccList.Add(new MailRecipient(
+                    mailUser.Email,
+                    mailUser.Name
+                ));
+            }
+            Cc(_ccList);
+
+            var _bccList = new List<MailRecipient>();
+            foreach (var mailUser in _email.Bcc)
+            {
+                _bccList.Add(new MailRecipient(
+                    mailUser.Email,
+                    mailUser.Name
+                ));
+            }
+            Bcc(_bccList);
+
+            if (_email.ReplyTo != null)
+            {
+                ReplyTo(new MailRecipient(
+                    _email.ReplyTo.Email,
+                    _email.ReplyTo.Name
+                ));
+            }
+        }
+    }
+}

--- a/Matcha.API/Startup.cs
+++ b/Matcha.API/Startup.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 using AutoMapper;
+using Coravel;
 using Matcha.API.Data;
 using Matcha.API.Helpers;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -79,6 +80,10 @@ namespace Matcha.API
                     };
                 });
             services.AddScoped<LogUserActivity>();
+
+            // Mailer services
+            services.AddScoped<IMailer, Mailer>();
+            services.AddMailer(new ConfigurationBuilder().AddJsonFile("appsettings.json", false).Build());
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Matcha.API/appsettings.json
+++ b/Matcha.API/appsettings.json
@@ -17,5 +17,16 @@
     "CloudName": "YourCloudName",
     "ApiKey": "YourApiKey",
     "ApiSecret": "YourApiSecret"
+  },
+  "Coravel": {
+    "Mail": {
+      "Driver": "SMTP",
+      "Host": "localhost",
+      "Port": 1025,
+      "From": {
+        "Address": "matcha@carteronline.net",
+        "Name": "MatchaSPA"
+      }
+      }
   }
 }


### PR DESCRIPTION
also bumps the dotnet version to 3.1
SMTP config is in Matcha.API/appsettings.json, already set up to use FakeSMTPServer
this just adds sending email capability, doesn't add any email sending itself